### PR TITLE
add color picker to onboard page

### DIFF
--- a/api/src/graphql/onboard.sdl.js
+++ b/api/src/graphql/onboard.sdl.js
@@ -2,6 +2,7 @@ export const schema = gql`
   input OnboardInput {
     userName: String!
     restaurantName: String!
+    brandColor: String!
   }
 
   type Mutation {

--- a/api/src/graphql/restaurants.sdl.js
+++ b/api/src/graphql/restaurants.sdl.js
@@ -18,6 +18,7 @@ export const schema = gql`
   input CreateRestaurantInput {
     name: String!
     ownerId: String!
+    brandColor: String!
   }
 
   input UpdateRestaurantInput {

--- a/api/src/services/onboard/onboard.js
+++ b/api/src/services/onboard/onboard.js
@@ -16,7 +16,10 @@ export const onboard = async ({ input }) => {
     return
   }
 
-  await createRestaurant({ name: input.restaurantName })
+  await createRestaurant({
+    name: input.restaurantName,
+    brandColor: input.brandColor,
+  })
   await updateUser(context.currentUser.id, {
     name: input.userName,
     onboarded: true,

--- a/api/src/services/restaurants/restaurants.js
+++ b/api/src/services/restaurants/restaurants.js
@@ -5,14 +5,14 @@ export const restaurants = () => {
   return db.restaurant.findMany()
 }
 
-export const createRestaurant = ({ name }) => {
+export const createRestaurant = ({ name, brandColor }) => {
   requireAuth()
 
   return db.restaurant.create({
     data: {
       name,
       sheetId: '',
-      brandColor: '#C81D25',
+      brandColor,
       owner: {
         connect: {
           id: context.currentUser.id,

--- a/web/src/hooks/UseOnClickOutside.js
+++ b/web/src/hooks/UseOnClickOutside.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-function UseOnClickOutside(ref, handler) {
+function useOnClickOutside(ref, handler) {
   useEffect(() => {
     const listener = (event) => {
       if (!ref.current || ref.current.contains(event.target)) {
@@ -18,4 +18,4 @@ function UseOnClickOutside(ref, handler) {
   }, [ref, handler])
 }
 
-export default UseOnClickOutside
+export default useOnClickOutside

--- a/web/src/pages/OnboardPage/OnboardPage.js
+++ b/web/src/pages/OnboardPage/OnboardPage.js
@@ -1,5 +1,5 @@
 import { navigate, routes } from '@redwoodjs/router'
-import UseOnClickOutside from '../../hooks/UseOnClickOutside'
+import useOnClickOutside from '../../hooks/useOnClickOutside'
 
 import { Form, Label, TextField, FieldError, Submit } from '@redwoodjs/forms'
 import { useMutation } from '@redwoodjs/web'
@@ -48,7 +48,7 @@ const OnboardPage = () => {
   }
 
   const colorPickerRef = useRef()
-  UseOnClickOutside(colorPickerRef, () => setDisplayColorPicker(false))
+  useOnClickOutside(colorPickerRef, () => setDisplayColorPicker(false))
 
   return (
     <main className="max-w-2xl mx-auto p-6">

--- a/web/src/pages/OnboardPage/OnboardPage.js
+++ b/web/src/pages/OnboardPage/OnboardPage.js
@@ -28,16 +28,12 @@ const OnboardPage = () => {
   const formMethods = useForm()
 
   const onSubmit = (data) => {
-    create({ variables: { input: data } })
+    create({ variables: { input: { ...data, brandColor: colorHex } } })
   }
 
   const [diplayColorPicker, setDisplayColorPicker] = useState(false)
-  const [color, setColor] = useState({
-    r: '241',
-    g: '112',
-    b: '19',
-    a: '1',
-  })
+
+  const [colorHex, setColorHex] = useState('#C81D25')
 
   const handleColorClick = () => {
     setDisplayColorPicker(!diplayColorPicker)
@@ -48,7 +44,7 @@ const OnboardPage = () => {
   }
 
   const handleColorChange = (color) => {
-    setColor(color.rgb)
+    setColorHex(color.hex)
   }
 
   const colorPickerRef = useRef()
@@ -114,7 +110,7 @@ const OnboardPage = () => {
               <div
                 className="w-12 h-8 border-r-1 rounded-md"
                 style={{
-                  backgroundColor: `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a} )`,
+                  backgroundColor: colorHex,
                 }}
               />
             </div>
@@ -127,7 +123,7 @@ const OnboardPage = () => {
                   role="button"
                   tabIndex={0}
                 />{' '}
-                <SketchPicker color={color} onChange={handleColorChange} />{' '}
+                <SketchPicker color={colorHex} onChange={handleColorChange} />{' '}
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
This PR:

- [x] adds color picker to onboard page
- [x] implements useRef hook to close color picker on outside click
- [x] Saves chosen color to backend